### PR TITLE
Rebuild ECSA fee calculator as a modern Vite React app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ECSA Fee Calculator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "ecsa-fee-calculator",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx"
+  },
+  "dependencies": {
+    "lucide-react": "^0.424.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "xlsx": "^0.18.5",
+    "jspdf": "^2.5.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,319 @@
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.08), transparent 45%), #f8fafc;
+}
+
+.header {
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
+  color: white;
+  padding: 2.5rem 1.5rem 5rem;
+  text-align: center;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-weight: 700;
+}
+
+.header p {
+  margin: 0.5rem auto 0;
+  max-width: 720px;
+  font-size: 1rem;
+  opacity: 0.92;
+}
+
+.content {
+  margin: -3rem auto 3rem;
+  width: min(1200px, 92vw);
+  background: white;
+  box-shadow: 0 30px 60px -30px rgba(15, 23, 42, 0.45);
+  border-radius: 24px;
+  padding: 2.5rem;
+}
+
+.tab-bar {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  padding: 0.5rem;
+  border-radius: 999px;
+  background: #eff6ff;
+}
+
+.tab-button {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab-button svg {
+  width: 20px;
+  height: 20px;
+}
+
+.tab-button.active {
+  background: white;
+  color: #0f172a;
+  box-shadow: 0 10px 30px -20px rgba(37, 99, 235, 0.6);
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin-bottom: 1.5rem;
+}
+
+.input-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: linear-gradient(145deg, white, #f8fbff);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.75rem;
+  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.55);
+}
+
+.card h3 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.field-group label {
+  font-weight: 600;
+  color: #1e293b;
+  font-size: 0.95rem;
+}
+
+.field-group input,
+.field-group select,
+.field-group textarea {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+  padding: 0.75rem 0.85rem;
+  font-size: 0.95rem;
+  background: white;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field-group input:focus,
+.field-group select:focus,
+.field-group textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.field-group small {
+  color: #64748b;
+  font-size: 0.8rem;
+}
+
+.radio-toggle {
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.35rem;
+  background: #eff6ff;
+  border-radius: 999px;
+}
+
+.radio-toggle button {
+  border: none;
+  padding: 0.5rem 1.1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  background: transparent;
+  color: #1d4ed8;
+  transition: all 0.2s ease;
+}
+
+.radio-toggle button.active {
+  background: white;
+  color: #0f172a;
+  box-shadow: 0 10px 20px -16px rgba(37, 99, 235, 0.6);
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: flex-end;
+  margin-top: 2rem;
+}
+
+.primary-button,
+.secondary-button {
+  border: none;
+  padding: 0.85rem 1.4rem;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: white;
+  box-shadow: 0 15px 30px -18px rgba(37, 99, 235, 0.7);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 30px -18px rgba(37, 99, 235, 0.8);
+}
+
+.secondary-button {
+  background: white;
+  color: #1d4ed8;
+  border: 1px solid rgba(37, 99, 235, 0.25);
+}
+
+.secondary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 30px -22px rgba(37, 99, 235, 0.6);
+}
+
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.result-card h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #1d4ed8;
+}
+
+.result-card .metric {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.75rem;
+}
+
+.metric label {
+  color: #475569;
+  font-weight: 500;
+}
+
+.metric span {
+  font-weight: 600;
+}
+
+.factor-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+}
+
+.factor-tag {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.stage-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.stage-table thead th {
+  text-align: left;
+  font-size: 0.8rem;
+  color: #64748b;
+  padding-bottom: 0.5rem;
+}
+
+.stage-table tbody td {
+  border-top: 1px solid rgba(226, 232, 240, 0.7);
+  padding: 0.5rem 0;
+  font-size: 0.85rem;
+}
+
+.summary-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.summary-tile {
+  background: linear-gradient(145deg, white, #f8fbff);
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 16px 36px -32px rgba(37, 99, 235, 0.65);
+}
+
+.summary-tile h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.summary-tile span {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.reference-section {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.reference-card ul {
+  margin: 0.75rem 0 0;
+  padding-left: 1.1rem;
+  color: #475569;
+}
+
+@media (max-width: 768px) {
+  .content {
+    padding: 1.75rem;
+  }
+
+  .tab-bar {
+    flex-direction: column;
+  }
+
+  .tab-button {
+    width: 100%;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,7 +100,7 @@ const App = () => {
       return totalCost && Math.abs(totalPercentage - 100) < 0.01;
     }
     return activeTables.length > 0;
-  }, [activeTables.length, inputMethod, totalCost, totalPercentage]);
+  }, [activeTables, inputMethod, totalCost, totalPercentage]);
 
   const exportToExcel = () => {
     if (!results) return;
@@ -166,12 +166,13 @@ const App = () => {
 
     const stageSheet = [['Table', 'Stage', 'Percentage', 'Amount']];
     Object.entries(results.stages).forEach(([tableId, breakdown]) => {
-      const stageDefinition = ECSA_DATA.stages[ECSA_DATA.tableStageMap[tableId]];
+      const stageKey = ECSA_DATA.tableStageMap[tableId];
+      const stageDefinition = stageKey ? ECSA_DATA.stages[stageKey] : undefined;
       Object.entries(breakdown).forEach(([stageName, amount]) => {
         stageSheet.push([
           tableId,
           stageName,
-          `${stageDefinition[stageName]}%`,
+          stageDefinition ? `${stageDefinition[stageName]}%` : 'N/A',
           formatCurrency(amount)
         ]);
       });
@@ -275,25 +276,28 @@ const App = () => {
         y += 14;
       }
 
-      const stageDefinition = ECSA_DATA.stages[ECSA_DATA.tableStageMap[category.tableId]];
-      doc.setTextColor('#1d4ed8');
-      doc.setFont('helvetica', 'bold');
-      doc.text('Stage allocation', margin, y);
-      y += 16;
+      const stageKey = ECSA_DATA.tableStageMap[category.tableId];
+      const stageDefinition = stageKey ? ECSA_DATA.stages[stageKey] : undefined;
+      if (stageDefinition) {
+        doc.setTextColor('#1d4ed8');
+        doc.setFont('helvetica', 'bold');
+        doc.text('Stage allocation', margin, y);
+        y += 16;
 
-      doc.setFont('helvetica', 'normal');
-      doc.setTextColor('#0f172a');
-      Object.entries(results.stages[category.tableId]).forEach(([stageName, amount]) => {
-        doc.text(
-          `${stageName} (${stageDefinition[stageName]}%): ${formatCurrency(amount)}`,
-          margin,
-          y
-        );
-        y += 14;
+        doc.setFont('helvetica', 'normal');
+        doc.setTextColor('#0f172a');
+        Object.entries(results.stages[category.tableId]).forEach(([stageName, amount]) => {
+          doc.text(
+            `${stageName} (${stageDefinition[stageName]}%): ${formatCurrency(amount)}`,
+            margin,
+            y
+          );
+          y += 14;
+        });
+
+        y += 12;
+      }
       });
-
-      y += 12;
-    });
 
     doc.save('ecsa-fee-calculation.pdf');
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,639 @@
+import { useMemo, useState } from 'react';
+import { Calculator, CheckCircle2, Download, FileText, Settings } from 'lucide-react';
+import { jsPDF } from 'jspdf';
+import * as XLSX from 'xlsx';
+import { ECSA_DATA, MIN_PROJECT_VALUE } from './data/ecsa';
+import { calculateFees, CalculationResult } from './utils/calculations';
+import { formatCurrency, formatPercent, parseNumber } from './utils/format';
+import './App.css';
+
+type TabKey = 'inputs' | 'results' | 'reference';
+
+type StringRecord = Record<string, string>;
+
+const createEmptyRecord = (): StringRecord => {
+  const record: StringRecord = {};
+  Object.keys(ECSA_DATA.tables).forEach((key) => {
+    record[key] = '';
+  });
+  return record;
+};
+
+const getFactorOptions = (tableId: string) => {
+  if (tableId === '1' || tableId === '2') {
+    return ECSA_DATA.factors['2A'] ?? [];
+  }
+  return ECSA_DATA.factors[`${tableId}A`] ?? [];
+};
+
+const App = () => {
+  const [activeTab, setActiveTab] = useState<TabKey>('inputs');
+  const [inputMethod, setInputMethod] = useState<'total' | 'category'>('total');
+  const [totalCost, setTotalCost] = useState('');
+  const [percentages, setPercentages] = useState<StringRecord>(() => createEmptyRecord());
+  const [categoryCosts, setCategoryCosts] = useState<StringRecord>(() => createEmptyRecord());
+  const [discounts, setDiscounts] = useState<StringRecord>(() => createEmptyRecord());
+  const [selectedFactors, setSelectedFactors] = useState<Record<string, string[]>>({});
+  const [results, setResults] = useState<CalculationResult | null>(null);
+
+  const totalPercentage = useMemo(
+    () =>
+      Object.values(percentages).reduce((acc, value) => acc + (value ? Number(value) : 0), 0),
+    [percentages]
+  );
+
+  const activeTables = useMemo(() => {
+    if (inputMethod === 'total') {
+      return Object.keys(percentages).filter((key) => Number(percentages[key] || 0) > 0);
+    }
+    return Object.keys(categoryCosts).filter((key) => Number(categoryCosts[key] || 0) > 0);
+  }, [categoryCosts, inputMethod, percentages]);
+
+  const resetForm = () => {
+    setPercentages(createEmptyRecord());
+    setCategoryCosts(createEmptyRecord());
+    setDiscounts(createEmptyRecord());
+    setSelectedFactors({});
+    setTotalCost('');
+    setResults(null);
+    setActiveTab('inputs');
+  };
+
+  const handleToggleFactor = (tableId: string, factorName: string) => {
+    setSelectedFactors((prev) => {
+      const current = prev[tableId] ?? [];
+      const exists = current.includes(factorName);
+      return {
+        ...prev,
+        [tableId]: exists ? current.filter((name) => name !== factorName) : [...current, factorName]
+      };
+    });
+  };
+
+  const handleCalculate = () => {
+    const numericTotal = parseNumber(totalCost);
+    const numericPercentages: Record<string, number> = {};
+    const numericCategoryCosts: Record<string, number> = {};
+    const numericDiscounts: Record<string, number> = {};
+
+    Object.keys(ECSA_DATA.tables).forEach((key) => {
+      numericPercentages[key] = Number(percentages[key] || 0);
+      numericCategoryCosts[key] = parseNumber(categoryCosts[key] || '');
+      numericDiscounts[key] = Number(discounts[key] || 0);
+    });
+
+    const calculation = calculateFees({
+      inputMethod,
+      totalCost: numericTotal,
+      percentages: numericPercentages,
+      categoryCosts: numericCategoryCosts,
+      discounts: numericDiscounts,
+      selectedFactors
+    });
+
+    setResults(calculation);
+    setActiveTab('results');
+  };
+
+  const canCalculate = useMemo(() => {
+    if (inputMethod === 'total') {
+      return totalCost && Math.abs(totalPercentage - 100) < 0.01;
+    }
+    return activeTables.length > 0;
+  }, [activeTables.length, inputMethod, totalCost, totalPercentage]);
+
+  const exportToExcel = () => {
+    if (!results) return;
+
+    const workbook = XLSX.utils.book_new();
+
+    const inputsSheet = [
+      ['ECSA Fee Calculator Inputs'],
+      ['Guideline: Government Gazette No. 52691 (16 May 2025)'],
+      [''],
+      ['Input method', inputMethod === 'total' ? 'Total project cost with percentages' : 'Direct category cost capture'],
+      ['Total project cost', totalCost ? formatCurrency(parseNumber(totalCost)) : 'Not specified'],
+      [''],
+      ['Category allocations']
+    ];
+
+    Object.values(ECSA_DATA.tables).forEach((table) => {
+      const cost =
+        inputMethod === 'total'
+          ? parseNumber(totalCost || '0') * (Number(percentages[table.id] || 0) / 100)
+          : parseNumber(categoryCosts[table.id] || '0');
+
+      inputsSheet.push([
+        `${table.id}: ${table.name}`,
+        inputMethod === 'total' ? `${Number(percentages[table.id] || 0)}%` : '',
+        cost ? formatCurrency(cost) : 'R 0.00'
+      ]);
+    });
+
+    const inputsWorksheet = XLSX.utils.aoa_to_sheet(inputsSheet);
+    XLSX.utils.book_append_sheet(workbook, inputsWorksheet, 'Inputs');
+
+    const calcSheet = [
+      [
+        'Table',
+        'Allocated Cost',
+        'Primary Fee',
+        'Secondary Fee',
+        'Basic Fee',
+        'Adjustment Factor',
+        'Discount %',
+        'Final Fee',
+        'Applied Factors'
+      ]
+    ];
+
+    Object.values(results.categories).forEach((category) => {
+      calcSheet.push([
+        `${category.tableId}: ${category.tableName}`,
+        formatCurrency(category.cost),
+        formatCurrency(category.primary),
+        formatCurrency(category.secondary),
+        formatCurrency(category.basic),
+        category.adjustmentFactor.toFixed(3),
+        `${category.discount.toFixed(2)}%`,
+        formatCurrency(category.discountedFee),
+        category.factors.join(', ') || 'None'
+      ]);
+    });
+
+    const calcWorksheet = XLSX.utils.aoa_to_sheet(calcSheet);
+    XLSX.utils.book_append_sheet(workbook, calcWorksheet, 'Calculations');
+
+    const stageSheet = [['Table', 'Stage', 'Percentage', 'Amount']];
+    Object.entries(results.stages).forEach(([tableId, breakdown]) => {
+      const stageDefinition = ECSA_DATA.stages[ECSA_DATA.tableStageMap[tableId]];
+      Object.entries(breakdown).forEach(([stageName, amount]) => {
+        stageSheet.push([
+          tableId,
+          stageName,
+          `${stageDefinition[stageName]}%`,
+          formatCurrency(amount)
+        ]);
+      });
+    });
+    const stageWorksheet = XLSX.utils.aoa_to_sheet(stageSheet);
+    XLSX.utils.book_append_sheet(workbook, stageWorksheet, 'Stages');
+
+    XLSX.writeFile(workbook, 'ecsa-fee-calculation.xlsx');
+  };
+
+  const exportToPdf = () => {
+    if (!results) return;
+
+    const doc = new jsPDF({ unit: 'pt', format: 'a4' });
+    const margin = 40;
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const pageHeight = doc.internal.pageSize.getHeight();
+    let y = margin;
+
+    const addHeading = (text: string, size = 16) => {
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(size);
+      doc.text(text, margin, y);
+      y += 24;
+    };
+
+    const ensureSpace = (height: number) => {
+      if (y + height > pageHeight - margin) {
+        doc.addPage();
+        y = margin;
+      }
+    };
+
+    doc.setTextColor('#1d4ed8');
+    addHeading('ECSA Fee Calculation Report', 20);
+    doc.setTextColor('#475569');
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.text('Guideline: Government Gazette No. 52691 (16 May 2025)', margin, y);
+    y += 12;
+    doc.text(`Generated: ${new Date().toLocaleString()}`, margin, y);
+    y += 20;
+
+    const summaryTile = (label: string, value: string) => {
+      doc.setDrawColor('#dbeafe');
+      doc.setFillColor('#eff6ff');
+      doc.roundedRect(margin, y, pageWidth - margin * 2, 44, 6, 6, 'FD');
+      doc.setTextColor('#1d4ed8');
+      doc.setFontSize(11);
+      doc.text(label, margin + 12, y + 18);
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(16);
+      doc.text(value, margin + 12, y + 34);
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(10);
+      doc.setTextColor('#475569');
+      y += 56;
+    };
+
+    summaryTile('Total undiscounted professional fee', formatCurrency(results.totals.undiscounted));
+    summaryTile('Total discounted professional fee', formatCurrency(results.totals.discounted));
+    summaryTile('Overall discount achieved', formatPercent(results.totals.overallDiscount));
+
+    addHeading('Detailed fee breakdown', 14);
+
+    Object.values(results.categories).forEach((category) => {
+      ensureSpace(140);
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(12);
+      doc.setTextColor('#1d4ed8');
+      doc.text(`${category.tableId}: ${category.tableName}`, margin, y);
+      y += 16;
+
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(10);
+      doc.setTextColor('#0f172a');
+      const metrics = [
+        ['Allocated cost', formatCurrency(category.cost)],
+        ['Primary fee', formatCurrency(category.primary)],
+        ['Secondary fee', formatCurrency(category.secondary)],
+        ['Basic fee', formatCurrency(category.basic)],
+        ['Adjustment factor', category.adjustmentFactor.toFixed(3)],
+        ['Discount applied', formatPercent(category.discount)],
+        ['Final fee', formatCurrency(category.discountedFee)]
+      ];
+
+      metrics.forEach(([label, value]) => {
+        doc.text(`${label}: ${value}`, margin, y);
+        y += 14;
+      });
+
+      if (category.factors.length) {
+        doc.setTextColor('#475569');
+        doc.text(`Factors applied: ${category.factors.join(', ')}`, margin, y);
+        y += 14;
+      }
+
+      if (category.note) {
+        doc.setTextColor('#b91c1c');
+        doc.text(category.note, margin, y, { maxWidth: pageWidth - margin * 2 });
+        y += 14;
+      }
+
+      const stageDefinition = ECSA_DATA.stages[ECSA_DATA.tableStageMap[category.tableId]];
+      doc.setTextColor('#1d4ed8');
+      doc.setFont('helvetica', 'bold');
+      doc.text('Stage allocation', margin, y);
+      y += 16;
+
+      doc.setFont('helvetica', 'normal');
+      doc.setTextColor('#0f172a');
+      Object.entries(results.stages[category.tableId]).forEach(([stageName, amount]) => {
+        doc.text(
+          `${stageName} (${stageDefinition[stageName]}%): ${formatCurrency(amount)}`,
+          margin,
+          y
+        );
+        y += 14;
+      });
+
+      y += 12;
+    });
+
+    doc.save('ecsa-fee-calculation.pdf');
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="header">
+        <h1>ECSA Professional Fee Calculator</h1>
+        <p>
+          Calculate professional fees in line with the Engineering Council of South Africa (ECSA)
+          guideline for 2025. Capture your project assumptions, apply relevant adjustment factors, and
+          export the results for record keeping.
+        </p>
+      </header>
+
+      <main className="content">
+        <div className="tab-bar">
+          <button
+            className={`tab-button ${activeTab === 'inputs' ? 'active' : ''}`}
+            onClick={() => setActiveTab('inputs')}
+          >
+            <Calculator />
+            Inputs
+          </button>
+          <button
+            className={`tab-button ${activeTab === 'results' ? 'active' : ''}`}
+            onClick={() => results && setActiveTab('results')}
+            disabled={!results}
+            style={!results ? { opacity: 0.4, cursor: 'not-allowed' } : undefined}
+          >
+            <CheckCircle2 />
+            Results
+          </button>
+          <button
+            className={`tab-button ${activeTab === 'reference' ? 'active' : ''}`}
+            onClick={() => setActiveTab('reference')}
+          >
+            <FileText />
+            Reference
+          </button>
+        </div>
+
+        {activeTab === 'inputs' && (
+          <section>
+            <div className="section-title">
+              <Settings />
+              Calculation setup
+            </div>
+
+            <div className="card" style={{ marginBottom: '1.5rem' }}>
+              <div className="field-group">
+                <label>How would you like to provide project costs?</label>
+                <div className="radio-toggle">
+                  <button
+                    type="button"
+                    className={inputMethod === 'total' ? 'active' : ''}
+                    onClick={() => setInputMethod('total')}
+                  >
+                    Total project value
+                  </button>
+                  <button
+                    type="button"
+                    className={inputMethod === 'category' ? 'active' : ''}
+                    onClick={() => setInputMethod('category')}
+                  >
+                    Capture per table
+                  </button>
+                </div>
+                {inputMethod === 'total' && (
+                  <>
+                    <label htmlFor="totalCost">Total project construction cost (ZAR)</label>
+                    <input
+                      id="totalCost"
+                      placeholder="e.g. 25 000 000"
+                      value={totalCost}
+                      onChange={(event) => setTotalCost(event.target.value)}
+                      inputMode="decimal"
+                    />
+                    <small>
+                      Projects below {formatCurrency(MIN_PROJECT_VALUE)} should be negotiated on a lump sum or
+                      time basis per the guideline.
+                    </small>
+                    <small>Total allocation: {totalPercentage.toFixed(2)}%</small>
+                    {Math.abs(totalPercentage - 100) > 0.01 && (
+                      <small style={{ color: '#b91c1c' }}>
+                        Ensure the allocation equals 100% before calculating.
+                      </small>
+                    )}
+                  </>
+                )}
+              </div>
+            </div>
+
+            <div className="input-grid">
+              {Object.values(ECSA_DATA.tables).map((table) => {
+                const factorOptions = getFactorOptions(table.id);
+                const selected = selectedFactors[table.id] ?? [];
+                return (
+                  <div className="card" key={table.id}>
+                    <h3>{table.name}</h3>
+                    <div className="field-group">
+                      {inputMethod === 'total' ? (
+                        <>
+                          <label htmlFor={`percentage-${table.id}`}>Allocation percentage</label>
+                          <input
+                            id={`percentage-${table.id}`}
+                            placeholder="0"
+                            value={percentages[table.id]}
+                            onChange={(event) =>
+                              setPercentages((prev) => ({ ...prev, [table.id]: event.target.value }))
+                            }
+                            inputMode="decimal"
+                          />
+                        </>
+                      ) : (
+                        <>
+                          <label htmlFor={`cost-${table.id}`}>Allocated cost (ZAR)</label>
+                          <input
+                            id={`cost-${table.id}`}
+                            placeholder="0"
+                            value={categoryCosts[table.id]}
+                            onChange={(event) =>
+                              setCategoryCosts((prev) => ({ ...prev, [table.id]: event.target.value }))
+                            }
+                            inputMode="decimal"
+                          />
+                        </>
+                      )}
+
+                      {factorOptions.length > 0 && (
+                        <div>
+                          <label>Applicable adjustment factors</label>
+                          <div className="factor-tags">
+                            {factorOptions.map((factor) => {
+                              const isSelected = selected.includes(factor.name);
+                              return (
+                                <button
+                                  key={factor.name}
+                                  type="button"
+                                  onClick={() => handleToggleFactor(table.id, factor.name)}
+                                  className="factor-tag"
+                                  style={{
+                                    background: isSelected ? 'rgba(37, 99, 235, 0.2)' : 'rgba(37,99,235,0.08)',
+                                    color: isSelected ? '#1d4ed8' : '#2563eb',
+                                    border: isSelected ? '1px solid rgba(37,99,235,0.3)' : '1px solid transparent'
+                                  }}
+                                >
+                                  {factor.name}
+                                  <span style={{ fontWeight: 400, marginLeft: 4 }}>×{factor.factor}</span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
+
+                      <label htmlFor={`discount-${table.id}`}>Discount (%)</label>
+                      <input
+                        id={`discount-${table.id}`}
+                        placeholder="0"
+                        value={discounts[table.id]}
+                        onChange={(event) =>
+                          setDiscounts((prev) => ({ ...prev, [table.id]: event.target.value }))
+                        }
+                        inputMode="decimal"
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="button-row">
+              <button className="secondary-button" type="button" onClick={resetForm}>
+                Reset inputs
+              </button>
+              <button
+                className="primary-button"
+                type="button"
+                onClick={handleCalculate}
+                disabled={!canCalculate}
+                style={!canCalculate ? { opacity: 0.6, cursor: 'not-allowed' } : undefined}
+              >
+                <Calculator />
+                Calculate fees
+              </button>
+            </div>
+          </section>
+        )}
+
+        {activeTab === 'results' && results && (
+          <section>
+            <div className="section-title">
+              <CheckCircle2 />
+              Calculation results
+            </div>
+
+            <div className="summary-tiles">
+              <div className="summary-tile">
+                <h4>Total undiscounted fee</h4>
+                <span>{formatCurrency(results.totals.undiscounted)}</span>
+              </div>
+              <div className="summary-tile">
+                <h4>Total discounted fee</h4>
+                <span>{formatCurrency(results.totals.discounted)}</span>
+              </div>
+              <div className="summary-tile">
+                <h4>Overall discount</h4>
+                <span>{formatPercent(results.totals.overallDiscount)}</span>
+              </div>
+            </div>
+
+            <div className="results-grid">
+              {activeTables.map((tableId) => {
+                const category = results.categories[tableId];
+                if (!category) return null;
+                const stages = results.stages[tableId];
+                const stageDefinition = ECSA_DATA.stages[ECSA_DATA.tableStageMap[tableId]];
+
+                return (
+                  <div className="card result-card" key={tableId}>
+                    <h4>{category.tableName}</h4>
+                    <div className="metric">
+                      <label>Allocated cost</label>
+                      <span>{formatCurrency(category.cost)}</span>
+                    </div>
+                    <div className="metric">
+                      <label>Primary fee</label>
+                      <span>{formatCurrency(category.primary)}</span>
+                    </div>
+                    <div className="metric">
+                      <label>Secondary fee</label>
+                      <span>{formatCurrency(category.secondary)}</span>
+                    </div>
+                    <div className="metric">
+                      <label>Basic fee</label>
+                      <span>{formatCurrency(category.basic)}</span>
+                    </div>
+                    <div className="metric">
+                      <label>Adjustment factor</label>
+                      <span>{category.adjustmentFactor.toFixed(3)}</span>
+                    </div>
+                    <div className="metric">
+                      <label>Discount</label>
+                      <span>{formatPercent(category.discount)}</span>
+                    </div>
+                    <div className="metric">
+                      <label>Final fee</label>
+                      <span>{formatCurrency(category.discountedFee)}</span>
+                    </div>
+
+                    {category.factors.length > 0 && (
+                      <div className="factor-tags">
+                        {category.factors.map((factor) => (
+                          <span key={factor} className="factor-tag">
+                            {factor}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    {category.note && <small style={{ color: '#b91c1c' }}>{category.note}</small>}
+
+                    <table className="stage-table">
+                      <thead>
+                        <tr>
+                          <th>Stage</th>
+                          <th>Percent</th>
+                          <th>Amount</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {Object.entries(stages).map(([stageName, amount]) => (
+                          <tr key={stageName}>
+                            <td>{stageName}</td>
+                            <td>{formatPercent(stageDefinition[stageName])}</td>
+                            <td>{formatCurrency(amount)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="button-row">
+              <button className="secondary-button" type="button" onClick={exportToExcel}>
+                <Download /> Export to Excel
+              </button>
+              <button className="primary-button" type="button" onClick={exportToPdf}>
+                <Download /> Export to PDF
+              </button>
+            </div>
+          </section>
+        )}
+
+        {activeTab === 'reference' && (
+          <section className="reference-section">
+            <div className="section-title">
+              <FileText />
+              Guideline highlights
+            </div>
+
+            <div className="card reference-card">
+              <h3>Using the calculator</h3>
+              <ul>
+                <li>
+                  The calculator enforces a minimum project value of {formatCurrency(MIN_PROJECT_VALUE)} in
+                  line with the ECSA guidance for negotiating smaller projects on a different basis.
+                </li>
+                <li>
+                  Adjustment factors can be combined; the multiplier applied is the product of the selected
+                  factors.
+                </li>
+                <li>Discounts are applied after adjustment factors for a transparent audit trail.</li>
+              </ul>
+            </div>
+
+            <div className="card reference-card">
+              <h3>Stage distribution reminder</h3>
+              <ul>
+                <li>
+                  Civil engineering projects distribute fees across six stages, with concept and design
+                  development receiving the highest weighting.
+                </li>
+                <li>
+                  Structural projects emphasise design development (30%) while building projects allocate a
+                  higher share to documentation.
+                </li>
+                <li>
+                  Mechanical and electrical projects reserve 35% for contract administration and inspection.
+                </li>
+              </ul>
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/src/data/ecsa.ts
+++ b/src/data/ecsa.ts
@@ -1,0 +1,221 @@
+export type FeeBracket = {
+  min: number;
+  max: number;
+  primary: number;
+  secondary: number;
+};
+
+export type TableDefinition = {
+  id: string;
+  name: string;
+  description?: string;
+  brackets: FeeBracket[];
+};
+
+export type AdjustmentFactor = {
+  name: string;
+  factor: number;
+  note?: string;
+};
+
+export type StageDefinition = Record<string, number>;
+
+export type EcsaData = {
+  tables: Record<string, TableDefinition>;
+  factors: Record<string, AdjustmentFactor[]>;
+  stages: Record<string, StageDefinition>;
+  tableStageMap: Record<string, keyof EcsaData['stages']>;
+};
+
+export const ECSA_DATA: EcsaData = {
+  tables: {
+    '1': {
+      id: '1',
+      name: 'Civil & Structural Engineering (Engineering Projects)',
+      description: 'Guideline fees for engineering projects as per Table 1.',
+      brackets: [
+        { min: 1_050_000, max: 2_100_000, primary: 178_500, secondary: 17.0 },
+        { min: 2_100_000, max: 10_500_000, primary: 336_000, secondary: 12.5 },
+        { min: 10_500_000, max: 21_000_000, primary: 1_386_000, secondary: 10.5 },
+        { min: 21_000_000, max: 52_500_000, primary: 2_488_500, secondary: 9.0 },
+        { min: 52_500_000, max: 105_000_000, primary: 5_323_500, secondary: 8.0 },
+        { min: 105_000_000, max: 630_000_000, primary: 9_523_500, secondary: 7.0 },
+        { min: 630_000_000, max: Number.POSITIVE_INFINITY, primary: 46_273_500, secondary: 6.0 }
+      ]
+    },
+    '2': {
+      id: '2',
+      name: 'Additional Design Fee: Reinforced Concrete & Structural Steel',
+      description: 'Supplementary fees in addition to Table 1 for reinforced concrete and structural steel.',
+      brackets: [
+        { min: 1_050_000, max: 2_100_000, primary: 84_000, secondary: 8.0 },
+        { min: 2_100_000, max: 10_500_000, primary: 157_500, secondary: 5.5 },
+        { min: 10_500_000, max: 21_000_000, primary: 619_500, secondary: 4.5 },
+        { min: 21_000_000, max: 52_500_000, primary: 1_092_000, secondary: 3.5 },
+        { min: 52_500_000, max: 105_000_000, primary: 2_194_500, secondary: 3.0 },
+        { min: 105_000_000, max: Number.POSITIVE_INFINITY, primary: 3_769_500, secondary: 2.5 }
+      ]
+    },
+    '3': {
+      id: '3',
+      name: 'Civil Engineering (Building Projects)',
+      brackets: [
+        { min: 1_050_000, max: 2_100_000, primary: 178_500, secondary: 17.0 },
+        { min: 2_100_000, max: 10_500_000, primary: 336_000, secondary: 12.5 },
+        { min: 10_500_000, max: 21_000_000, primary: 1_386_000, secondary: 10.5 },
+        { min: 21_000_000, max: 52_500_000, primary: 2_488_500, secondary: 9.5 },
+        { min: 52_500_000, max: Number.POSITIVE_INFINITY, primary: 5_481_000, secondary: 8.5 }
+      ]
+    },
+    '4': {
+      id: '4',
+      name: 'Structural Engineering (Building Projects)',
+      brackets: [
+        { min: 1_050_000, max: 2_100_000, primary: 178_500, secondary: 17.0 },
+        { min: 2_100_000, max: 10_500_000, primary: 336_000, secondary: 12.5 },
+        { min: 10_500_000, max: 21_000_000, primary: 1_386_000, secondary: 10.5 },
+        { min: 21_000_000, max: 52_500_000, primary: 2_488_500, secondary: 9.5 },
+        { min: 52_500_000, max: Number.POSITIVE_INFINITY, primary: 5_481_000, secondary: 8.5 }
+      ]
+    },
+    '5': {
+      id: '5',
+      name: 'Mechanical Engineering (Engineering Projects)',
+      brackets: [
+        { min: 1_050_000, max: 2_100_000, primary: 178_500, secondary: 17.0 },
+        { min: 2_100_000, max: 10_500_000, primary: 336_000, secondary: 12.5 },
+        { min: 10_500_000, max: 21_000_000, primary: 1_386_000, secondary: 10.5 },
+        { min: 21_000_000, max: 52_500_000, primary: 2_488_500, secondary: 9.0 },
+        { min: 52_500_000, max: 105_000_000, primary: 5_323_500, secondary: 8.0 },
+        { min: 105_000_000, max: 630_000_000, primary: 9_523_500, secondary: 7.0 },
+        { min: 630_000_000, max: Number.POSITIVE_INFINITY, primary: 46_273_500, secondary: 6.5 }
+      ]
+    },
+    '6': {
+      id: '6',
+      name: 'Electrical Engineering (Engineering Projects)',
+      brackets: [
+        { min: 1_050_000, max: 2_100_000, primary: 178_500, secondary: 17.0 },
+        { min: 2_100_000, max: 10_500_000, primary: 336_000, secondary: 12.5 },
+        { min: 10_500_000, max: 21_000_000, primary: 1_386_000, secondary: 10.5 },
+        { min: 21_000_000, max: 52_500_000, primary: 2_488_500, secondary: 9.0 },
+        { min: 52_500_000, max: 105_000_000, primary: 5_323_500, secondary: 8.0 },
+        { min: 105_000_000, max: 630_000_000, primary: 9_523_500, secondary: 7.0 },
+        { min: 630_000_000, max: Number.POSITIVE_INFINITY, primary: 46_273_500, secondary: 6.5 }
+      ]
+    },
+    '7': {
+      id: '7',
+      name: 'Mechanical Engineering (Building Projects)',
+      brackets: [
+        { min: 1_050_000, max: 2_100_000, primary: 210_000, secondary: 20.0 },
+        { min: 2_100_000, max: 10_500_000, primary: 399_000, secondary: 15.0 },
+        { min: 10_500_000, max: 21_000_000, primary: 1_659_000, secondary: 13.0 },
+        { min: 21_000_000, max: 52_500_000, primary: 3_024_000, secondary: 11.5 },
+        { min: 52_500_000, max: 105_000_000, primary: 6_646_500, secondary: 10.5 },
+        { min: 105_000_000, max: 630_000_000, primary: 12_159_000, secondary: 10.0 }
+      ]
+    },
+    '8': {
+      id: '8',
+      name: 'Electrical Engineering (Building Projects)',
+      brackets: [
+        { min: 1_050_000, max: 2_100_000, primary: 210_000, secondary: 20.0 },
+        { min: 2_100_000, max: 10_500_000, primary: 399_000, secondary: 15.0 },
+        { min: 10_500_000, max: 21_000_000, primary: 1_659_000, secondary: 13.0 },
+        { min: 21_000_000, max: 52_500_000, primary: 3_024_000, secondary: 11.5 },
+        { min: 52_500_000, max: 105_000_000, primary: 6_646_500, secondary: 10.5 },
+        { min: 105_000_000, max: Number.POSITIVE_INFINITY, primary: 12_159_000, secondary: 10.0 }
+      ]
+    }
+  },
+  factors: {
+    '2A': [
+      { name: 'Rural roads', factor: 0.85 },
+      { name: 'Alterations to existing works', factor: 1.25 },
+      { name: 'Duplication of works', factor: 0.25 },
+      { name: 'Financial administration handled by QS', factor: 0.85 }
+    ],
+    '3A': [
+      { name: 'Alterations to existing works', factor: 1.25 },
+      { name: 'Internal water and drainage for buildings', factor: 1.25 },
+      { name: 'Mass concrete foundations, brickwork and cladding', factor: 0.33 },
+      { name: 'Duplication of works', factor: 0.25 }
+    ],
+    '4A': [
+      { name: 'Alterations to existing works', factor: 1.25 },
+      { name: 'Mass concrete foundations, brickwork and cladding', factor: 0.33 },
+      { name: 'Duplication of works', factor: 0.25 }
+    ],
+    '5A': [
+      { name: 'Multi-tenant installations', factor: 1.25 },
+      { name: 'Alterations to existing works', factor: 1.25 },
+      { name: 'Duplication of works', factor: 0.25 },
+      { name: 'Financial administration handled by QS', factor: 0.85 }
+    ],
+    '6A': [
+      { name: 'Multi-tenant installations', factor: 1.25 },
+      { name: 'Alterations to existing works', factor: 1.25 },
+      { name: 'Duplication of works', factor: 0.25 },
+      { name: 'Financial administration handled by QS', factor: 0.85 }
+    ],
+    '7A': [
+      { name: 'Multi-tenant installations', factor: 1.25 },
+      { name: 'Alterations to existing works', factor: 1.25 },
+      { name: 'Duplication of works', factor: 0.25 },
+      { name: 'Financial administration handled by QS', factor: 0.85 }
+    ],
+    '8A': [
+      { name: 'Multi-tenant installations', factor: 1.25 },
+      { name: 'Alterations to existing works', factor: 1.25 },
+      { name: 'Duplication of works', factor: 0.25 },
+      { name: 'Financial administration handled by QS', factor: 0.85 }
+    ]
+  },
+  stages: {
+    'Civil Engineering Projects': {
+      'Inception': 5,
+      'Concept and Viability': 25,
+      'Design Development': 25,
+      'Documentation and Procurement': 25,
+      'Contract Administration and Inspection': 15,
+      'Close-Out': 5
+    },
+    'Structural Engineering Projects': {
+      'Inception': 5,
+      'Concept and Viability': 25,
+      'Design Development': 30,
+      'Documentation and Procurement': 10,
+      'Contract Administration and Inspection': 25,
+      'Close-Out': 5
+    },
+    'Building Projects': {
+      'Inception': 5,
+      'Concept and Viability': 25,
+      'Design Development': 25,
+      'Documentation and Procurement': 15,
+      'Contract Administration and Inspection': 25,
+      'Close-Out': 5
+    },
+    'Mechanical and Electrical Projects': {
+      'Inception': 5,
+      'Concept and Viability': 15,
+      'Design Development': 20,
+      'Documentation and Procurement': 20,
+      'Contract Administration and Inspection': 35,
+      'Close-Out': 5
+    }
+  },
+  tableStageMap: {
+    '1': 'Civil Engineering Projects',
+    '2': 'Civil Engineering Projects',
+    '3': 'Building Projects',
+    '4': 'Structural Engineering Projects',
+    '5': 'Mechanical and Electrical Projects',
+    '6': 'Mechanical and Electrical Projects',
+    '7': 'Mechanical and Electrical Projects',
+    '8': 'Mechanical and Electrical Projects'
+  }
+};
+
+export const MIN_PROJECT_VALUE = 1_000_000;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,19 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+button, input, select {
+  font-family: inherit;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,4 +1,4 @@
-import { ECSA_DATA, TableDefinition } from '../data/ecsa';
+import { ECSA_DATA, MIN_PROJECT_VALUE, TableDefinition } from '../data/ecsa';
 
 export type FeeComputation = {
   tableId: string;
@@ -26,13 +26,11 @@ export type CalculationResult = {
   stages: Record<string, StageBreakdown>;
 };
 
-const MIN_COST = 1_000_000;
-
 const findBracket = (table: TableDefinition, cost: number) =>
   table.brackets.find((bracket) => cost >= bracket.min && cost < bracket.max);
 
 const computeFee = (table: TableDefinition, cost: number) => {
-  if (cost < MIN_COST) {
+  if (cost < MIN_PROJECT_VALUE) {
     return {
       primary: 0,
       secondary: 0,
@@ -135,7 +133,10 @@ export const calculateFees = ({
   const stages: Record<string, StageBreakdown> = {};
   Object.values(categories).forEach((category) => {
     const stageKey = ECSA_DATA.tableStageMap[category.tableId];
-    const stageDefinition = ECSA_DATA.stages[stageKey];
+    const stageDefinition = stageKey ? ECSA_DATA.stages[stageKey] : undefined;
+    if (!stageDefinition) {
+      return;
+    }
     const stageBreakdown: StageBreakdown = {};
 
     Object.entries(stageDefinition).forEach(([stageName, percentage]) => {

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,0 +1,157 @@
+import { ECSA_DATA, TableDefinition } from '../data/ecsa';
+
+export type FeeComputation = {
+  tableId: string;
+  tableName: string;
+  cost: number;
+  primary: number;
+  secondary: number;
+  basic: number;
+  factors: string[];
+  adjustmentFactor: number;
+  discount: number;
+  discountedFee: number;
+  note?: string;
+};
+
+export type StageBreakdown = Record<string, number>;
+
+export type CalculationResult = {
+  categories: Record<string, FeeComputation>;
+  totals: {
+    undiscounted: number;
+    discounted: number;
+    overallDiscount: number;
+  };
+  stages: Record<string, StageBreakdown>;
+};
+
+const MIN_COST = 1_000_000;
+
+const findBracket = (table: TableDefinition, cost: number) =>
+  table.brackets.find((bracket) => cost >= bracket.min && cost < bracket.max);
+
+const computeFee = (table: TableDefinition, cost: number) => {
+  if (cost < MIN_COST) {
+    return {
+      primary: 0,
+      secondary: 0,
+      basic: 0,
+      note: 'Projects under R1,000,000 should be negotiated on a lump sum or time basis.'
+    };
+  }
+
+  const bracket = findBracket(table, cost);
+  if (!bracket) {
+    return {
+      primary: 0,
+      secondary: 0,
+      basic: 0,
+      note: 'Cost falls outside of the configured brackets.'
+    };
+  }
+
+  const primary = bracket.primary;
+  const secondary = (cost - bracket.min) * (bracket.secondary / 100);
+  const basic = primary + secondary;
+
+  return { primary, secondary, basic };
+};
+
+const resolveFactorList = (tableId: string, selected: string[]): string[] => {
+  if (!selected.length) {
+    return [];
+  }
+
+  if (tableId === '1' || tableId === '2') {
+    const table = ECSA_DATA.factors['2A'] ?? [];
+    return selected.filter((name) => table.some((factor) => factor.name === name));
+  }
+
+  const factorTable = ECSA_DATA.factors[`${tableId}A`] ?? [];
+  return selected.filter((name) => factorTable.some((factor) => factor.name === name));
+};
+
+export type CalculationInputs = {
+  inputMethod: 'total' | 'category';
+  totalCost: number;
+  percentages: Record<string, number>;
+  categoryCosts: Record<string, number>;
+  discounts: Record<string, number>;
+  selectedFactors: Record<string, string[]>;
+};
+
+export const calculateFees = ({
+  inputMethod,
+  totalCost,
+  percentages,
+  categoryCosts,
+  discounts,
+  selectedFactors
+}: CalculationInputs): CalculationResult => {
+  const categories: Record<string, FeeComputation> = {};
+  let totalUndiscounted = 0;
+  let totalDiscounted = 0;
+
+  Object.values(ECSA_DATA.tables).forEach((table) => {
+    const cost = inputMethod === 'total' ? (totalCost * (percentages[table.id] ?? 0)) / 100 : categoryCosts[table.id] ?? 0;
+
+    if (!cost) {
+      return;
+    }
+
+    const fee = computeFee(table, cost);
+
+    const selection = resolveFactorList(table.id, selectedFactors[table.id] ?? []);
+    const adjustmentFactor = selection.reduce((acc, name) => {
+      const factor = (table.id === '1' || table.id === '2' ? ECSA_DATA.factors['2A'] : ECSA_DATA.factors[`${table.id}A`])?.find(
+        (item) => item.name === name
+      );
+      return factor ? acc * factor.factor : acc;
+    }, 1);
+
+    const adjustedFee = fee.basic * adjustmentFactor;
+    const discount = discounts[table.id] ?? 0;
+    const discountedFee = adjustedFee * (1 - discount / 100);
+
+    categories[table.id] = {
+      tableId: table.id,
+      tableName: table.name,
+      cost,
+      primary: fee.primary,
+      secondary: fee.secondary,
+      basic: fee.basic,
+      factors: selection,
+      adjustmentFactor,
+      discount,
+      discountedFee,
+      note: fee.note
+    };
+
+    totalUndiscounted += adjustedFee;
+    totalDiscounted += discountedFee;
+  });
+
+  const stages: Record<string, StageBreakdown> = {};
+  Object.values(categories).forEach((category) => {
+    const stageKey = ECSA_DATA.tableStageMap[category.tableId];
+    const stageDefinition = ECSA_DATA.stages[stageKey];
+    const stageBreakdown: StageBreakdown = {};
+
+    Object.entries(stageDefinition).forEach(([stageName, percentage]) => {
+      stageBreakdown[stageName] = (category.discountedFee * percentage) / 100;
+    });
+
+    stages[category.tableId] = stageBreakdown;
+  });
+
+  const totals = {
+    undiscounted: totalUndiscounted,
+    discounted: totalDiscounted,
+    overallDiscount: totalUndiscounted
+      ? ((totalUndiscounted - totalDiscounted) / totalUndiscounted) * 100
+      : 0
+  };
+
+  return { categories, stages, totals };
+};

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,10 @@
+export const formatCurrency = (value: number): string =>
+  `R ${value.toLocaleString('en-ZA', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+export const formatPercent = (value: number): string =>
+  `${value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}%`;
+
+export const parseNumber = (value: string): number => {
+  const normalized = value.replace(/[^0-9.-]+/g, '');
+  return normalized ? Number(normalized) : 0;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- replace the legacy snippet with a full Vite + React TypeScript application and modernised UI styling
- implement reusable data definitions and calculation utilities covering fee brackets, adjustment factors, and stage allocations
- add export workflows for PDF and Excel outputs plus formatting helpers and project configuration files

## Testing
- npm install *(fails: 403 Forbidden when downloading @types/react)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b786a59c8333b3b8809709625651